### PR TITLE
constrain image width to container

### DIFF
--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -248,7 +248,8 @@ pre {
 
 main img {
   display: block;
-  margin: 0.5rem auto;  
+  margin: 0.5rem auto;
+  max-width: 100%;
 }
 
 table {


### PR DESCRIPTION
Before:
<img width="1171" height="932" alt="image" src="https://github.com/user-attachments/assets/70a75bd5-faf3-4fed-a28f-48c1e12a669e" />

After:
<img width="751" height="623" alt="image" src="https://github.com/user-attachments/assets/b17c9e69-2d60-4ef7-abfb-cff7deaf08d3" />
