### PR TITLE
fix description list overflow

### DIFF
--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -431,7 +431,7 @@ ol li {
 
 dl {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto minmax(0, 1fr);
   grid-gap: 0.2rem 1rem;
 
   dt {
@@ -442,6 +442,11 @@ dl {
   dd {
     grid-column-start: 2;
     margin: 0;
+    min-width: 0;
+
+    pre {
+      margin: 0;
+    }
   }
 }
 


### PR DESCRIPTION
Before:
<img width="768" height="199" alt="image" src="https://github.com/user-attachments/assets/ed9d42ad-8d4e-43ce-9d52-7f7c1bef15a1" />

After:
<img width="639" height="203" alt="image" src="https://github.com/user-attachments/assets/0a6fa22a-4b3a-499b-ad05-7f9107ce75d7" />
