### PR TITLE
center figcaption below figures

### DIFF
--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -252,6 +252,20 @@ main img {
   max-width: 100%;
 }
 
+main figure {
+  margin: 1rem auto;
+  text-align: center;
+}
+
+main figcaption {
+  text-align: center;
+  font-size: 0.8rem;
+
+  @media (prefers-color-scheme: dark) {
+    color: #555;
+  }
+}
+
 table {
   width: 100%;
   border-collapse: collapse;

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -248,7 +248,8 @@ pre {
 
 main img {
   display: block;
-  margin: 0.5rem auto;  
+  margin: 0.5rem auto;
+  max-width: 100%;
 }
 
 table {


### PR DESCRIPTION
Merge this after #68 

Before:
<img width="785" height="920" alt="image" src="https://github.com/user-attachments/assets/d1cb8e69-bc7e-436e-9e26-0ab1f1476c90" />

After:
<img width="737" height="685" alt="image" src="https://github.com/user-attachments/assets/d8b903e2-465b-4a4c-82af-2f11b8b57466" />
